### PR TITLE
Se arregla un bug en linux

### DIFF
--- a/Back-end/src/database.ts
+++ b/Back-end/src/database.ts
@@ -2,7 +2,7 @@ import mongoose, { ConnectOptions } from 'mongoose'
 import dotenv from 'dotenv';
 dotenv.config();
 
-const uri = `mongodb+srv://${process.env.USER}:${process.env.PASSWORD}@cluster0.vtdaa.mongodb.net/${process.env.DBNAME}?retryWrites=true&w=majority`;
+const uri = `mongodb+srv://${process.env.MONGO_USER}:${process.env.MONGO_PASS}@cluster0.vtdaa.mongodb.net/${process.env.MONGO_DBNAME}?retryWrites=true&w=majority`;
 
 export async function startConnection() {
     try {


### PR DESCRIPTION
Habia un bug en linux, que hacia que cuando se armara la url de la base de datos, tomara la variable de entorno USER del sistema linux, y no la definida por .env
Cambiar el .env del backend por:

ORIGIN_FRONT_IP=http://localhost:4200

MONGO_USER=api-lacta-planet
MONGO_PASS=haiP9eUqFIPxlWCr
MONGO_DBNAME=jwt-lactaproject

TOKEN_SECRET=MARCIANEKE
