### PR TITLE
Edit control

### DIFF
--- a/Back-end/src/routes/Control/control.controller.ts
+++ b/Back-end/src/routes/Control/control.controller.ts
@@ -64,6 +64,12 @@ export const newControl: RequestHandler = async (req, res) => {
     return res.status(201).send({ success: true, data: { _id: controlSaved._id }, message: 'Control agregado con éxito al sistema.' });
 }
 
+/**
+ * Función que maneja la petición de editar un control al sistema.
+ * @route Put /control/:idControl
+ * @param req Request de la petición, se espera que tenga la información del control editado
+ * @param res Response, retorna un un object con success:true, data:{} y un message: "String" del control editado si todo sale bien
+ */
 export const editControl: RequestHandler = async (req, res) => {
 
 }

--- a/Back-end/src/routes/Control/control.controller.ts
+++ b/Back-end/src/routes/Control/control.controller.ts
@@ -71,11 +71,11 @@ export const newControl: RequestHandler = async (req, res) => {
  * @param res Response, retorna un un object con success:true, data:{} y un message: "String" del control editado si todo sale bien
  */
 export const editControl: RequestHandler = async (req, res) => {
-    const _id = req.params.id;
+    const _id = req.params.idControl;
     const updatedControl = req.body;
 
     //se valida el _id de la madre ingresada
-    if ( !Types.ObjectId.isValid(_id) )
+    if ( !Types.ObjectId.isValid( _id) )
         return res.status(400).send({ success: false, data:{}, message: 'ERROR: El id ingresado no es válido.' });
 
     const controlFound = await Control.findById( _id );

--- a/Back-end/src/routes/Control/control.controller.ts
+++ b/Back-end/src/routes/Control/control.controller.ts
@@ -71,7 +71,23 @@ export const newControl: RequestHandler = async (req, res) => {
  * @param res Response, retorna un un object con success:true, data:{} y un message: "String" del control editado si todo sale bien
  */
 export const editControl: RequestHandler = async (req, res) => {
+    const _id = req.params.id;
+    const updatedControl = req.body;
 
+    //se valida el _id de la madre ingresada
+    if ( !Types.ObjectId.isValid(_id) )
+        return res.status(400).send({ success: false, data:{}, message: 'ERROR: El id ingresado no es válido.' });
+
+    const controlFound = await Control.findById( _id );
+
+    //se valida la existencia del control en el sistema
+    if ( !controlFound )
+        return res.status(404).send({ success: false, data:{}, message: 'ERROR: El control ingresado no existe en el sistema.' });
+
+    //se actualiza el control en el sistema
+    await Control.findByIdAndUpdate( _id, updatedControl );
+
+    return res.status(200).send({ success: true, data:{}, message: 'Control editado de manera correcta.' });
 }
 
 export const deleteControl: RequestHandler = async (req, res) => {

--- a/Back-end/src/routes/Control/control.controller.ts
+++ b/Back-end/src/routes/Control/control.controller.ts
@@ -1,6 +1,5 @@
 import { RequestHandler } from "express";
 import { Types } from "mongoose";
-import Mother from '../Mother/mother.model';
 import Control from './control.model';
 import Child from '../Child/child.model';
 


### PR DESCRIPTION
Se estructura editControl. Esta función tiene la labor de editar las citas proximas y actualizar la cita que se esta llevando a cabo (desde la plantilla seguimiento) .
 No se solicita child_name para el edit, ya que en addControl el edit es tomado directamente desde la bd a través de su id_child, por lo tanto, no existe margen de error en caso de que "alguna matrona ingrese mal el nombre y quiera modificarlo".
Entonces, los datos que solicita son: 
![imagen](https://user-images.githubusercontent.com/39105967/142075842-9a3200da-c559-4ac6-b843-f0ec127ca2c7.png)

O:
![imagen](https://user-images.githubusercontent.com/39105967/142076052-12b335d4-d93b-4099-8b33-d033c52c04d5.png)

Con su IdControl por parámetro en ambos.


pd: Cabe destacar que no hice validaciones de atributos, dando por hecho que desde el front existen 2 formularios distintos de edit, que serían plantilla de seguimiento y agendar proxima cita. Donde tambien, esos formularios no deberían permiir el edit del child_name.