### PR TITLE
Se quita el fondo de los formularios y se agrega más responsividad al fondo por defecto de la página

### DIFF
--- a/Front-end/lactaProject/src/app/Modules/childs/pages/child-form/child-form.component.html
+++ b/Front-end/lactaProject/src/app/Modules/childs/pages/child-form/child-form.component.html
@@ -1,4 +1,4 @@
-<body>
+<div>
     <div class="top-bar">
         <a (click)="goToMotherProfile()" mdbBtn color="" class="backButton" mdbWavesEffect>
             <i class="fas fa-long-arrow-alt-left"></i>
@@ -332,4 +332,4 @@
             </form>
         </div>
     </div>
-</body>
+</div>

--- a/Front-end/lactaProject/src/app/Modules/childs/pages/child-form/child-form.component.scss
+++ b/Front-end/lactaProject/src/app/Modules/childs/pages/child-form/child-form.component.scss
@@ -1,14 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500;600;700&display=swap');
 @import "/src/styles/palette.scss";
 
-body{
-    min-width: 320px;
-    background-image: none;
-    width: 100%;
-    min-height: 100vh;
-    background-color: $light-blue;
-}
-
 form{
     width: 100%;
 }
@@ -40,6 +32,7 @@ form{
     display: flex;
     flex-wrap: wrap;
     border: 4px solid white;
+    background-color: $light-blue;
 }
 
 .form-container{

--- a/Front-end/lactaProject/src/app/Modules/controls/pages/first-control-form/first-control-form.component.html
+++ b/Front-end/lactaProject/src/app/Modules/controls/pages/first-control-form/first-control-form.component.html
@@ -1,4 +1,4 @@
-<body>
+<div>
     <div class="top-bar">
         <a (click)="goToMotherProfile()" mdbBtn color="" class="backButton" mdbWavesEffect>
             <i class="fas fa-long-arrow-alt-left"></i>
@@ -201,4 +201,4 @@
             </form>
         </div>
     </div>
-</body>
+</div>

--- a/Front-end/lactaProject/src/app/Modules/controls/pages/first-control-form/first-control-form.component.scss
+++ b/Front-end/lactaProject/src/app/Modules/controls/pages/first-control-form/first-control-form.component.scss
@@ -1,14 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500;600;700&display=swap');
 @import "/src/styles/palette.scss";
 
-body{
-    min-width: 320px;
-    background-image: none;
-    width: 100%;
-    min-height: 100vh;
-    background-color: $pink;
-}
-
 form{
     width: 100%;
 }
@@ -40,6 +32,7 @@ form{
     display: flex;
     flex-wrap: wrap;
     border: 4px solid white;
+    background-color: $pink;
 }
 
 .form-container{

--- a/Front-end/lactaProject/src/app/Modules/login/pages/postlogin-view/postlogin-view.component.html
+++ b/Front-end/lactaProject/src/app/Modules/login/pages/postlogin-view/postlogin-view.component.html
@@ -1,4 +1,4 @@
-<body>
+<div class="component-container">
     <div class="container">
         <div class="form-container">
             <form [formGroup]="postlogin" (ngSubmit)="buenas()">
@@ -21,4 +21,4 @@
             </form>
         </div>
     </div>
-</body>
+</div>

--- a/Front-end/lactaProject/src/app/Modules/login/pages/postlogin-view/postlogin-view.component.scss
+++ b/Front-end/lactaProject/src/app/Modules/login/pages/postlogin-view/postlogin-view.component.scss
@@ -1,4 +1,4 @@
-body{
+.component-container{
     width: 100%;
     height: 100vh;
     background-position: center center;

--- a/Front-end/lactaProject/src/app/Modules/mothers/pages/mother-form/mother-form.component.html
+++ b/Front-end/lactaProject/src/app/Modules/mothers/pages/mother-form/mother-form.component.html
@@ -1,4 +1,4 @@
-<body>
+<div>
     <div class="top-bar">
         <a (click)="goLastPage()" mdbBtn color="" class="backButton" mdbWavesEffect>
             <i class="fas fa-long-arrow-alt-left"></i>
@@ -238,4 +238,4 @@
             </form>
         </div>
     </div>
-</body>
+</div>

--- a/Front-end/lactaProject/src/app/Modules/mothers/pages/mother-form/mother-form.component.scss
+++ b/Front-end/lactaProject/src/app/Modules/mothers/pages/mother-form/mother-form.component.scss
@@ -1,13 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@600&display=swap');
 @import "/src/styles/palette.scss";
 
-body{
-    background-image: none;
-    width: 100%;
-    min-width: 320px;
-    background-color: $pink;
-}
-
 form{
     width: 100%;
 }
@@ -38,6 +31,7 @@ form{
     display: flex;
     flex-wrap: wrap;
     border: 4px solid white;
+    background-color: $pink;
 }
 
 .form-container{

--- a/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.html
+++ b/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.html
@@ -1,4 +1,4 @@
-<body>
+<div>
     <div class="top-bar">
         <a href="profesionales" mdbBtn color="" class="backButton" mdbWavesEffect>
             <i class="fas fa-long-arrow-alt-left"></i>
@@ -133,4 +133,4 @@
             </form>
         </div>
     </div>
-</body>
+</div>

--- a/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.scss
+++ b/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.scss
@@ -1,14 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@600&display=swap');
 @import "/src/styles/palette.scss";
 
-body{
-    min-width: 320px;
-    background-image: none;
-    width: 100%;
-    min-height: 100vh;
-    background-color: $light-blue;
-}
-
 form{
     width: 100%;
 }
@@ -40,6 +32,7 @@ form{
     display: flex;
     flex-wrap: wrap;
     border: 4px solid white;
+    background-color: $light-blue;
 }
 
 .form-container{

--- a/Front-end/lactaProject/src/styles.scss
+++ b/Front-end/lactaProject/src/styles.scss
@@ -10,5 +10,6 @@ body{
     background-repeat: no-repeat;
     background-size: 100%;
     background-color:$light-blue;
-
+    background-size: cover;
+    background-attachment: fixed;
 }


### PR DESCRIPTION
Se quita el fondo de los formularios, he aquí un ejemplo de como se ven ahora:
![image](https://user-images.githubusercontent.com/81885522/159101491-895d500e-95aa-4e32-b1b7-d925b9af54a8.png)
![image](https://user-images.githubusercontent.com/81885522/159101559-1ef59825-2ce2-48e4-b94d-98d023e123a5.png)

Se agrega un poco de más responsividad al fondo por defecto de la página:
![image](https://user-images.githubusercontent.com/81885522/159101526-483caf0b-7620-4a70-a773-8c88aaa3a486.png)
