### PR TITLE
Fix crear profesional

### DIFF
--- a/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.html
+++ b/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.html
@@ -77,7 +77,27 @@
                         </div>
                     </div>
                 </div>
-
+                 <!-- Password -->
+                 <div class="input-label-container"> 
+                    <label class="label-text">Password:</label>
+                    <div class="password-container">
+                        <input type="password" class="form-control" formControlName="password" placeholder="Contraseña" maxlength="20"
+                        [ngClass]="{ 'is-invalid': form.controls['password'].invalid && (form.controls['password'].dirty || form.controls['password'].touched),
+                        'is-valid': form.controls['password'].valid && (form.controls['password'].dirty || form.controls['password'].touched)  }">
+                    </div>
+                    <div *ngIf="form.controls['password'].invalid && (form.controls['password'].dirty || form.controls['password'].touched)">
+                        <div *ngIf="form.controls['password']?.hasError('required')" > 
+                            <div class="invalid-text">
+                                Debe rellenar el campo
+                            </div>
+                        </div>
+                        <div *ngIf="form.controls['password']?.hasError('minlength')" > 
+                            <div class="invalid-text">
+                                Minimo 6 digitos de largo
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <!-- Mail -->
                 <div class="input-label-container"> 
                     <label class="label-text">Mail:</label>

--- a/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.html
+++ b/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.html
@@ -78,7 +78,7 @@
                     </div>
                 </div>
                  <!-- Password -->
-                 <div class="input-label-container"> 
+                 <div class="input-label-container" *ngIf="id == '0'"> 
                     <label class="label-text">Password:</label>
                     <div class="password-container">
                         <input type="password" class="form-control" formControlName="password" placeholder="Contraseña" maxlength="20"

--- a/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.ts
+++ b/Front-end/lactaProject/src/app/Modules/professionals/pages/professional-form/professional-form.component.ts
@@ -22,6 +22,7 @@ export class ProfessionalFormComponent implements OnInit {
       name: ['', Validators.required],
       rut: ['', [Validators.required,Validators.pattern("^[0-9]{7,8}$")]],
       rut_vc: ['', [Validators.required,Validators.pattern("^[0-9kK]{1}$")]],
+      password: ['', [Validators.required,Validators.minLength(6)]],
       mail: ['', [Validators.email, Validators.required]],
       permission_level: ['0', Validators.required]
     });


### PR DESCRIPTION
Se vuelve a agregar el campo de contraseña:
![image](https://user-images.githubusercontent.com/81885522/164357164-9623f704-2bb1-427e-bf69-78ac8f178d39.png)
Se oculta el campo de contraseña al momento de editar al usuario:
![image](https://user-images.githubusercontent.com/81885522/164357273-11fd29fa-5db7-4326-a83f-63f7bf31e3b2.png)
